### PR TITLE
[Ticket 2] Add device-dependent utility for remote workspace mounting

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@
 @author: Tianhan Tang (tianhantang.pd@gmail.com)
 @date:
 - created on 2025-01-18
-- updated on 2025-01-18
+- updated on 2025-01-19
 +++
 
 === Introduction
@@ -12,6 +12,36 @@
 It is a collection of scripts and functions that I use in my daily work.
 
 It is inspired by [Oh My Zsh](https://ohmyz.sh).
+
+=== Advanced usage
+
+--- To use the device-dependent `Mount-Workspace` function
+
+One needs to create a JSON file to store the necessary parameters for the remote storage mount operation for their system.
+The content may look like this (`+++ JSON` and `+++` are part of the content):
+```
++++ JSON
+{
+	WkspID: {
+		MountPoint: "~/Workspace",
+		HostID: "MyServer",
+		VolumeID: "WKSP",
+		VolumeType: "smbfs",
+		UserID: "foo"
+		UserPSW: "hogehoge"
+	}
+}
++++
+```
+
+Then encrypt the JSON file with GPG, e.g.
++++ command
+gpg --encrypt --armor --recipient tianhantang.pd@gmail.com ./workspace-info
++++
+
+Put the encrypted file in the dedicated ohmypwsh config directory---for macOS, it is `~/.ohmypwsh.d/workspace-info.asc`.
+
+There you go, the `Mount-Workspace` function will auto load the parameters from the encrypted JSON file, and mount the remote storage for you by calling `Mount-Workspace WkspID`.
 
 === Guideline for contribution
 

--- a/conf/device-00-pwsh-conf.ps1
+++ b/conf/device-00-pwsh-conf.ps1
@@ -49,7 +49,7 @@ Function Mount-Workspace {
 			throw "Workspace $WkspID is not recognized, please confirm the information file at $WKSP_INFO_FILE."
 		}
 		# @note: the user should ensure the integrity of the workspace information
-		Mount-RemoteVolume -WkspID $WkspID `
+		Mount-RemoteVolume `
 			-MountPoint $wksp_info[$WkspID].MountPoint `
 			-HostID $wksp_info[$WkspID].HostID `
 			-VolumeID $wksp_info[$WkspID].VolumeID `
@@ -100,7 +100,7 @@ Function Remove-Workspace {
 			throw "Workspace $WkspID is not recognized, please confirm the information file at $WKSP_INFO_FILE."
 		}
 		# @note: the user should ensure the integrity of the workspace information
-		Remove-RemoteVolume -WkspID $WkspID -MountPoint $wksp_info[$WkspID].MountPoint
+		Remove-RemoteVolume -MountPoint $wksp_info[$WkspID].MountPoint
 	} catch {
 		Write-Error $_.Exception.Message
 	}

--- a/conf/device-00-pwsh-conf.ps1
+++ b/conf/device-00-pwsh-conf.ps1
@@ -68,49 +68,40 @@ Function Mount-Workspace {
 # - `man umount`
 Function Remove-Workspace {
 	param(
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$WkspID,      # workspace identifier
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$MountPoint   # mount point
+		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$WkspID # workspace identifier
 	)
-	if ("W4:" -eq $WkspID) { # Currently only support W4:
-		if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point does not exist
-			Write-Error "The specified mount point '$MountPoint' does not exist or is not mounted."
-			return
+	$WKSP_INFO_FILE = "~/.ohmypwsh.d/workspace-info.asc" # GPG encrypted file of workspace information
+	try {
+		if (-not (Test-Path $WKSP_INFO_FILE -PathType Leaf)) {
+			throw "Workspace information file '$WKSP_INFO_FILE' does not exist."
 		}
-		try {
-			# Call system command `umount`
-			umount $MountPoint 2>$null
-			if (-not $?) {
-				# Fallback mechanism for force un-mounting
-				diskutil unmount force $MountPoint
-				if (-not $?) {
-					throw "Failed to unmount '$WkspID' from '$MountPoint'."
-				}
+		# Decrypt the GPG encrypted file
+		$decrypted = gpg --decrypt $WKSP_INFO_FILE 2>$null
+		if (-not $?) {
+			throw "Failed to decrypt the workspace information file '$WKSP_INFO_FILE'."
+		}
+		# Extract the JSON content marked by '+++ JSON' and '+++'
+		$json = @()
+		$flag = $false
+		$decrypted | ForEach-Object {
+			if ('+++' -eq $_) {
+				$flag = $false
+			} # Prevent the boundary line from being included in the output
+			if ($flag) {
+				$json += $_
 			}
-			# Clean up
-			Remove-Item -Path $MountPoint -ErrorAction Stop
-			Write-Output "Successfully unmounted '$WkspID' from '$MountPoint' and cleaned up the directory."
-		} catch {
-			Write-Error $_.Exception.Message
+			if ('+++ JSON' -eq $_) {
+				$flag = $true
+			} # Enable the NEXT line to be included in the output
 		}
-	} else {
-		Write-Error "Workspace '$WkspID' is not supported in this version."
-	}
-}
-
-Function Get-Secret {
-	$content = Get-Content -Path '~/.ohmypwsh.d/workspace-info'
-	$json = @()
-	$flag = $false
-	$content | ForEach-Object {
-		if ('+++' -eq $_) {
-			$flag = $false
-		} # Prevent the boundary line from being included in the output
-		if ($flag) {
-			$json += $_
+		$wksp_info = ConvertFrom-Json ($json -join [System.Environment]::NewLine) -AsHashtable -ErrorAction Stop
+		# Un-mount the workspace using the retrieved information
+		if ($null -eq $wksp_info[$WkspID]) {
+			throw "Workspace $WkspID is not recognized, please confirm the information file at $WKSP_INFO_FILE."
 		}
-		if ('+++ JSON' -eq $_) {
-			$flag = $true
-		} # Enable the NEXT line to be included in the output
+		# @note: the user should ensure the integrity of the workspace information
+		Remove-RemoteVolume -WkspID $WkspID -MountPoint $wksp_info[$WkspID].MountPoint
+	} catch {
+		Write-Error $_.Exception.Message
 	}
-	return $json
 }

--- a/conf/device-00-pwsh-conf.ps1
+++ b/conf/device-00-pwsh-conf.ps1
@@ -8,53 +8,56 @@
 
 	@date:
 	- created on 2021-08-09
-	- updated on 2025-01-18	
+	- updated on 2025-01-19
 #>
 
 # === Function definition
 
 # @brief: Mount remote shared storage as a workspace
-# @note:
-# - `UrlEncode` is used to encode the volume name to handle no-ASCII characters (e.g. Japanese)
-# - This function utilizes the macOS built-in (BSD) `mount`, make sure the path is properly set
-# @see: `man mount`
+# @details: It is basically a wrapper around the platform-specific function `Mount-RemoteVolume`
 Function Mount-Workspace {
 	param(
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$WkspID,        # workspace identifier
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$MountPoint,    # mount point
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$HostID,        # host identifier, IP or hostname
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$VolumeID,      # shared volume identifier
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$VolumeType,    # protocol of the shared volume
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$UserID,        # user identifier
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$UserPSW        # passphrase
+		[Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)][string]$WkspID
 	)
-	if ("W4:" -eq $WkspID) { # Currently only support W4:
-		if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point already exists, since it may be local workspace
-			$mount_target = "//${UserID}:${UserPSW}@${HostID}/$([System.Web.HttpUtility]::UrlEncode($VolumeID))"
-			try {
-				New-Item -ItemType Directory -Path $MountPoint -ErrorAction Stop 1>$null
-				# Call system comamnd `mount`
-				if ("smbfs" -ne $VolumeType) { # Currently only support SMB protocol for shared volume mounting
-					throw "Volume type '$VolumeType' is not supported in this version."
-				}
-				mount -t smbfs $mount_target $MountPoint
-				if ($?) {
-					Write-Output "Successfully created mount point '$MountPoint' for '$WkspID'."
-				} else {
-					throw "Failed to mount '$WkspID' at '$MountPoint'."
-				}
-			} catch {
-				Write-Error $_.Exception.Message
-				# Clean up
-				if (Test-Path $MountPoint -PathType Container) {
-					Remove-Item -Path $MountPoint -Recurse -Force -ErrorAction SilentlyContinue
-				}
-			}
-		} else {
-			Write-Error "Mount point '$WkspID' already exists! Please take care!"
+	$WKSP_INFO_FILE = "~/.ohmypwsh.d/workspace-info.asc" # GPG encrypted file of workspace information
+	try {
+		if (-not (Test-Path $WKSP_INFO_FILE -PathType Leaf)) {
+			throw "Workspace information file '$WKSP_INFO_FILE' does not exist."
 		}
-	} else {
-		Write-Error "Workspace '$WkspID' is not supported in this version."
+		# Decrypt the GPG encrypted file
+		$decrypted = gpg --decrypt $WKSP_INFO_FILE 2>$null
+		if (-not $?) {
+			throw "Failed to decrypt the workspace information file '$WKSP_INFO_FILE'."
+		}
+		# Extract the JSON content marked by '+++ JSON' and '+++'
+		$json = @()
+		$flag = $false
+		$decrypted | ForEach-Object {
+			if ('+++' -eq $_) {
+				$flag = $false
+			} # Prevent the boundary line from being included in the output
+			if ($flag) {
+				$json += $_
+			}
+			if ('+++ JSON' -eq $_) {
+				$flag = $true
+			} # Enable the NEXT line to be included in the output
+		}
+		$wksp_info = ConvertFrom-Json ($json -join [System.Environment]::NewLine) -AsHashtable -ErrorAction Stop
+		# Mount the workspace using the retrieved information
+		if ($null -eq $wksp_info[$WkspID]) {
+			throw "Workspace $WkspID is not recognized, please confirm the information file at $WKSP_INFO_FILE."
+		}
+		# @note: the user should ensure the integrity of the workspace information
+		Mount-RemoteVolume -WkspID $WkspID `
+			-MountPoint $wksp_info[$WkspID].MountPoint `
+			-HostID $wksp_info[$WkspID].HostID `
+			-VolumeID $wksp_info[$WkspID].VolumeID `
+			-VolumeType $wksp_info[$WkspID].VolumeType `
+			-UserID $wksp_info[$WkspID].UserID `
+			-UserPSW $wksp_info[$WkspID].UserPSW
+	} catch {
+		Write-Error $_.Exception.Message
 	}
 }
 
@@ -92,4 +95,22 @@ Function Remove-Workspace {
 	} else {
 		Write-Error "Workspace '$WkspID' is not supported in this version."
 	}
+}
+
+Function Get-Secret {
+	$content = Get-Content -Path '~/.ohmypwsh.d/workspace-info'
+	$json = @()
+	$flag = $false
+	$content | ForEach-Object {
+		if ('+++' -eq $_) {
+			$flag = $false
+		} # Prevent the boundary line from being included in the output
+		if ($flag) {
+			$json += $_
+		}
+		if ('+++ JSON' -eq $_) {
+			$flag = $true
+		} # Enable the NEXT line to be included in the output
+	}
+	return $json
 }

--- a/conf/macos-pwsh-conf.ps1
+++ b/conf/macos-pwsh-conf.ps1
@@ -78,7 +78,7 @@ Function Remove-RemoteVolume {
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$WkspID,      # workspace identifier
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$MountPoint   # mount point
 	)
-	if ("W4:" -eq $WkspID) { # Currently only support W4:
+	if ("W4" -eq $WkspID) { # Currently only support W4:
 		if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point does not exist
 			Write-Error "The specified mount point '$MountPoint' does not exist or is not mounted."
 			return

--- a/conf/macos-pwsh-conf.ps1
+++ b/conf/macos-pwsh-conf.ps1
@@ -37,7 +37,7 @@ Function Mount-RemoteVolume {
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$UserID,        # user identifier
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$UserPSW        # passphrase
 	)
-	if ("W4:" -eq $WkspID) { # Currently only support W4:
+	if ("W4" -eq $WkspID) { # Currently only support W4:
 		if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point already exists, since it may be local workspace
 			$mount_target = "//${UserID}:${UserPSW}@${HostID}/$([System.Web.HttpUtility]::UrlEncode($VolumeID))"
 			try {

--- a/conf/macos-pwsh-conf.ps1
+++ b/conf/macos-pwsh-conf.ps1
@@ -13,7 +13,7 @@
 
 	@date:
 	- created on 2021-08-09
-	- updated on 2025-01-18
+	- updated on 2025-01-19
 #>
 
 # === Environment setup
@@ -29,7 +29,6 @@ Set-Item -Path "env:GPG_TTY" -Value "$(tty)" # configure GPG_TTY such that gpg-a
 # @see: `man mount`
 Function Mount-RemoteVolume {
 	param(
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$WkspID,        # workspace identifier
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$MountPoint,    # mount point
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$HostID,        # host identifier, IP or hostname
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$VolumeID,      # shared volume identifier
@@ -37,33 +36,29 @@ Function Mount-RemoteVolume {
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$UserID,        # user identifier
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$UserPSW        # passphrase
 	)
-	if ("W4" -eq $WkspID) { # Currently only support W4:
-		if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point already exists, since it may be local workspace
-			$mount_target = "//${UserID}:${UserPSW}@${HostID}/$([System.Web.HttpUtility]::UrlEncode($VolumeID))"
-			try {
-				New-Item -ItemType Directory -Path $MountPoint -ErrorAction Stop 1>$null
-				# Call system comamnd `mount`
-				if ("smbfs" -ne $VolumeType) { # Currently only support SMB protocol for shared volume mounting
-					throw "Volume type '$VolumeType' is not supported in this version."
-				}
-				mount -t smbfs $mount_target $MountPoint
-				if ($?) {
-					Write-Output "Successfully created mount point '$MountPoint' for '$WkspID'."
-				} else {
-					throw "Failed to mount '$WkspID' at '$MountPoint'."
-				}
-			} catch {
-				Write-Error $_.Exception.Message
-				# Clean up
-				if (Test-Path $MountPoint -PathType Container) {
-					Remove-Item -Path $MountPoint -Recurse -Force -ErrorAction SilentlyContinue
-				}
+	if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point already exists, since it may be local workspace
+		$mount_target = "//${UserID}:${UserPSW}@${HostID}/$([System.Web.HttpUtility]::UrlEncode($VolumeID))"
+		try {
+			New-Item -ItemType Directory -Path $MountPoint -ErrorAction Stop 1>$null
+			# Call system comamnd `mount`
+			if ("smbfs" -ne $VolumeType) { # Currently only support SMB protocol for shared volume mounting
+				throw "Volume type '$VolumeType' is not supported in this version."
 			}
-		} else {
-			Write-Error "Mount point '$WkspID' already exists! Please take care!"
+			mount -t smbfs $mount_target $MountPoint
+			if ($?) {
+				Write-Output "Successfully created mount point at '$MountPoint'."
+			} else {
+				throw "Failed to mount at '$MountPoint'."
+			}
+		} catch {
+			Write-Error $_.Exception.Message
+			# Clean up
+			if (Test-Path $MountPoint -PathType Container) {
+				Remove-Item -Path $MountPoint -Recurse -Force -ErrorAction SilentlyContinue
+			}
 		}
 	} else {
-		Write-Error "Workspace '$WkspID' is not supported in this version."
+		Write-Error "Mount point '$MountPoint' already exists! Please take care!"
 	}
 }
 
@@ -75,31 +70,26 @@ Function Mount-RemoteVolume {
 # - `man diskutil`
 Function Remove-RemoteVolume {
 	param(
-		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$WkspID,      # workspace identifier
 		[Parameter(Mandatory = $true, ValueFromPipeline = $false)][string]$MountPoint   # mount point
 	)
-	if ("W4" -eq $WkspID) { # Currently only support W4:
-		if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point does not exist
-			Write-Error "The specified mount point '$MountPoint' does not exist or is not mounted."
-			return
-		}
-		try {
-			# Call system command `umount`
-			umount $MountPoint 2>$null
+	if (-not (Test-Path $MountPoint -PathType Container)) { # Abort if the mount point does not exist
+		Write-Error "The specified mount point '$MountPoint' does not exist or is not mounted."
+		return
+	}
+	try {
+		# Call system command `umount`
+		umount $MountPoint 2>$null
+		if (-not $?) {
+			# Fallback mechanism for force un-mounting
+			diskutil unmount force $MountPoint
 			if (-not $?) {
-				# Fallback mechanism for force un-mounting
-				diskutil unmount force $MountPoint
-				if (-not $?) {
-					throw "Failed to unmount '$WkspID' from '$MountPoint'."
-				}
+				throw "Failed to unmount '$MountPoint'."
 			}
-			# Clean up
-			Remove-Item -Path $MountPoint -ErrorAction Stop
-			Write-Output "Successfully unmounted '$WkspID' from '$MountPoint' and cleaned up the directory."
-		} catch {
-			Write-Error $_.Exception.Message
 		}
-	} else {
-		Write-Error "Workspace '$WkspID' is not supported in this version."
+		# Clean up
+		Remove-Item -Path $MountPoint -ErrorAction Stop
+		Write-Output "Successfully unmounted '$MountPoint' and cleaned up the directory."
+	} catch {
+		Write-Error $_.Exception.Message
 	}
 }

--- a/tickets.txt
+++ b/tickets.txt
@@ -53,7 +53,7 @@ As for the dark theme, which will generally based on a near-black background, I 
 @brief:
 Add `Mount-Workspace` command.
 
-@status: PROGRESSING
+@status: DONE
 
 @date:
 - created on 2025-01-16
@@ -75,23 +75,26 @@ Add `Mount-Workspace` for my personal Mac to mount the routine remote workspace,
 @status: DONE
 
 @details:
-- The function only handles a specific workspace Identifier `W4:`
+- The function only handles a specific workspace Identifier `W4`
 - It should hard-code NO secret in the script
 - The function call requires all parameters to be passed in, including the remote storage URL, the local mount point, and the username/password.
 
 --- Ticket 2-2
 
 @brief:
-Make `Mount-Workspace W4:` work as it is, w/o provide any additional parameters.
+Make `Mount-Workspace W4` work as it is, w/o provide any additional parameters.
 
-@status: TODO
+@status: DONE
 
 @date:
 - created on 2025-01-18
-- updated on 2025-01-18
+- updated on 2025-01-19
 
 @details:
-Need to devise a mechanism to auto handle the remote storage URL, the local mount point, and the username/password, in a secure way.
+By using an external JSON file, the function can auto load the parameters (w/o cache) per call, and fill all the necessary parameters for the `Mount-Workspace` function.
+As long as the JSON file is not exposed to the public, the secret info. should be safe.
+Beyonds that, I added one more layer of security---instead of reading info. from a plain JSON file, I use an GPG-encrypted JSON file, and decrypt it on-the-fly.
+This method fits well for the scenario of *device-dependent* `Mount-Workspace` function.
 
 === Ticket 3
 


### PR DESCRIPTION
## brief
Make `Mount-Workspace WkspID` work as it is, w/o providing any additional parameters.

## details
By using an external JSON file, the function can auto load the parameters (w/o cache) per call, and fill all the necessary parameters for the `Mount-Workspace` function.
As long as the JSON file is not exposed to the public, the secret info. should be safe.
Beyonds that, I added one more layer of security---instead of reading info. from a plain JSON file, I use an GPG-encrypted JSON file, and decrypt it on-the-fly.
This method fits well for the scenario of *device-dependent* `Mount-Workspace` function.

## note
Currently, those remote storage mounting utilities only works on macOS.